### PR TITLE
Various fixes

### DIFF
--- a/terraform-import-github-org.sh
+++ b/terraform-import-github-org.sh
@@ -15,7 +15,7 @@ ORG=''
   # You can only list 100 items per page, so you can only clone 100 at a time.
   # This function uses the API to calculate how many pages of public repos you have.
 get_public_pagination () {
-  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&per_page=100" | grep -o '&page=.*.' | grep -Eo '[0-9]*' | tail -1
+  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1
 }
   # This function uses the output from above and creates an array counting from 1->$ 
 limit_public_pagination () {
@@ -59,7 +59,7 @@ EOF
 
 # Private Repos
 get_private_pagination () {
-  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=private&per_page=100" | grep -o '&page=.*.' | grep -Eo '[0-9]*' | tail -1
+  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=private&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1
 }
 
 limit_private_pagination () {
@@ -182,7 +182,7 @@ EOF
 }
 
 get_team_pagination () {
-  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&per_page=100" | grep -o '&page=.*.' | grep -Eo '[0-9]*' | tail -1
+  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1
 }
   # This function uses the out from above and creates an array counting from 1->$ 
 limit_team_pagination () {

--- a/terraform-import-github-org.sh
+++ b/terraform-import-github-org.sh
@@ -38,10 +38,7 @@ import_public_repos () {
      
       # Terraform doesn't like '.' in resource names, so if one exists then replace it with a dash
       TERRAFORM_PUBLIC_REPO_NAME=$(echo $i | tr  "."  "-")
-  
-      # Import the Repo
-      terraform import github_repository.$TERRAFORM_PUBLIC_REPO_NAME $i
-  
+
       cat >> github-public-repos.tf << EOF
 resource "github_repository" "$TERRAFORM_PUBLIC_REPO_NAME" {
   name        = "$i"
@@ -53,6 +50,8 @@ resource "github_repository" "$TERRAFORM_PUBLIC_REPO_NAME" {
 }
 EOF
 
+      # Import the Repo
+      terraform import github_repository.$TERRAFORM_PUBLIC_REPO_NAME $i
     done
   done
 }
@@ -81,10 +80,7 @@ import_private_repos () {
      
       # Terraform doesn't like '.' in resource names, so if one exists then replace it with a dash
       TERRAFORM_PRIVATE_REPO_NAME=$(echo $i | tr  "."  "-")
-  
-      # Import the Repo
-      terraform import github_repository.$TERRAFORM_PRIVATE_REPO_NAME $i
-  
+
       cat >> github-private-repos.tf << EOF
 resource "github_repository" "$TERRAFORM_PRIVATE_REPO_NAME" {
   name        = "$i"
@@ -96,24 +92,24 @@ resource "github_repository" "$TERRAFORM_PRIVATE_REPO_NAME" {
 }
 
 EOF
-
-    done 
+      # Import the Repo
+      terraform import github_repository.$TERRAFORM_PRIVATE_REPO_NAME $i
+    done
   done
 }
 
 # Users
 import_users () {
   for i in $(curl -s "https://api.github.com/orgs/$ORG/members?access_token=$GITHUB_TOKEN&per_page=100" | jq -r 'sort_by(.login) | .[] | .login'); do
-  terraform import github_membership.$i $ORG:$i
-  
+
   cat >> github-users.tf << EOF
 resource "github_membership" "$i" {
   username        = "$i"
   role            = "member"
 }
 EOF
-
-  done 
+    terraform import github_membership.$i $ORG:$i
+  done
 }
 
 # Teams
@@ -121,8 +117,6 @@ import_teams () {
   for i in $(curl -s "https://api.github.com/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
   
     TEAM_NAME=$(curl -s "https://api.github.com/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
-  
-    terraform import github_team.$TEAM_NAME $i
 
     TEAM_PRIVACY=$(curl -s "https://api.github.com/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .privacy)
   
@@ -145,6 +139,8 @@ resource "github_team" "$TEAM_NAME" {
 }
 EOF
     fi
+
+    terraform import github_team.$TEAM_NAME $i
   done
 }
 
@@ -157,9 +153,7 @@ import_team_memberships () {
     for j in $(curl -s "https://api.github.com/teams/$i/members?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .[].login); do
     
       TEAM_ROLE=$(curl -s "https://api.github.com/teams/$i/memberships/$j?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .role)
-    
-      terraform import github_team_membership.$TEAM_NAME-$j $i:$j
-    
+
       if [[ "$TEAM_ROLE" == "maintainer" ]]; then
         cat >> github-team-memberships-$TEAM_NAME.tf << EOF
 resource "github_team_membership" "$TEAM_NAME-$j" {
@@ -177,6 +171,7 @@ resource "github_team_membership" "$TEAM_NAME-$j" {
 }
 EOF
       fi
+      terraform import github_team_membership.$TEAM_NAME-$j $i:$j
     done
   done
 }
@@ -200,9 +195,7 @@ get_team_repos () {
     
     TERRAFORM_TEAM_REPO_NAME=$(echo $i | tr  "."  "-")
     TEAM_NAME=$(curl -s "https://api.github.com/teams/$TEAM_ID?access_token=$GITHUB_TOKEN" | jq -r .name)
-    
-    terraform import github_team_repository.$TEAM_NAME-$TERRAFORM_TEAM_REPO_NAME $TEAM_ID:$i
-    
+
     ADMIN_PERMS=$(curl -s "https://api.github.com/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.admin )
     PUSH_PERMS=$(curl -s "https://api.github.com/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.push )
     PULL_PERMS=$(curl -s "https://api.github.com/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.pull )
@@ -235,6 +228,7 @@ resource "github_team_repository" "$TEAM_NAME-$TERRAFORM_TEAM_REPO_NAME" {
 
 EOF
     fi
+    terraform import github_team_repository.$TEAM_NAME-$TERRAFORM_TEAM_REPO_NAME $TEAM_ID:$i
     done
   done
 }

--- a/terraform-import-github-org.sh
+++ b/terraform-import-github-org.sh
@@ -28,8 +28,8 @@ import_public_repos () {
   
     for i in $(curl -s "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
   
-      PUBLIC_REPO_DESCRIPTION=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .description)
   
+      PUBLIC_REPO_DESCRIPTION=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .description | sed "s/\"/'/g")
       PUBLIC_REPO_DOWNLOADS=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_downloads)
       
       PUBLIC_REPO_WIKI=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_wiki)


### PR DESCRIPTION
Hi, thanks for sharing this! Saved us a bunch of time. We encountered a few issues while working with the script, included in the PR are fixes for the following:

* Public repositories with `"` (double quotes) in their description resulted in invalid hcl.
* The pagination id extraction failed.
* The `terraform import` commands were failing as the target resources did not exist in the templates at runtime.