### PR TITLE
Make it work for me

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ resource "github_membership" "$USER_NAME" {
 - A github [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with the following permissions:
   - repo (all)
   - admin:org (all)
-  - delete_repo
 - Terraform
 - jq
 

--- a/README.md
+++ b/README.md
@@ -97,12 +97,37 @@ resource "github_membership" "$USER_NAME" {
 
 ### Do it
 - `git clone` this repo
+- create a basic terraform configuration file, e.g. `main.tf` with
+  something like:
+
+  ```hcl
+  provider "github" {
+    token        = "TOKENGOESHERE"
+    organization = "my_org"
+    # optional, if using GitHub Enterprise
+    base_url     =  "https://github.mycompany.com/api/v3/"
+  }
+  ```
+- run `terraform init` to e.g. install the GitHub provider
 - configure the variables at the top of the script
-  - GITHUB_TOKEN=''
-  - ORG=''
-- run the script
+  - `GITHUB_TOKEN=...`
+  - `ORG=...`
+  - if you're using GitHub Enterprise, `API_URL_PREFIX=...`
+  or remember to pass them in via the environment
+- run the scriptm, perhaps passing the necessary environment variables
+  ```
+  GITHUB_TOKEN=12334...4555 ORG=my_org terraform-import-github-org.sh
+  ```
 - run a terraform plan to see that everything was imported and that no changes are required.
   - some manual modifications _could_ be required since not every field supported by Terraform has been implemented by this script.
+  - HEADS UP - the script hardcodes user roles to "member".
+
+### Using with GitHub Enterprise
+
+This should also work with GitHub Enterprise deployments if you also
+set (either editing the script or via an environment variable) the
+`API_URL_PREFIX` correctly,
+e.g. `https://github.mycompany.com/api/v3`.
 
 # FAQ
 - Q) Why bash?

--- a/terraform-import-github-org.sh
+++ b/terraform-import-github-org.sh
@@ -4,8 +4,9 @@
 ###
 ## GLOBAL VARIABLES
 ###
-GITHUB_TOKEN=''
-ORG=''
+GITHUB_TOKEN=${GITHUB_TOKEN:-''}
+ORG=${ORG:-''}
+API_URL_PREFIX=${API_URL_PREFIX:-'https://github.com'}
 
 ###
 ## FUNCTIONS
@@ -15,7 +16,8 @@ ORG=''
   # You can only list 100 items per page, so you can only clone 100 at a time.
   # This function uses the API to calculate how many pages of public repos you have.
 get_public_pagination () {
-  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1
+    public_pages=$(curl -I "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
+    echo ${public_pages:-1}
 }
   # This function uses the output from above and creates an array counting from 1->$ 
 limit_public_pagination () {
@@ -26,15 +28,15 @@ limit_public_pagination () {
 import_public_repos () {
   for PAGE in $(limit_public_pagination); do
   
-    for i in $(curl -s "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
+    for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
   
   
-      PUBLIC_REPO_DESCRIPTION=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .description | sed "s/\"/'/g")
-      PUBLIC_REPO_DOWNLOADS=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_downloads)
+      PUBLIC_REPO_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .description | sed "s/\"/'/g")
+      PUBLIC_REPO_DOWNLOADS=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_downloads)
       
-      PUBLIC_REPO_WIKI=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_wiki)
+      PUBLIC_REPO_WIKI=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_wiki)
       
-      PUBLIC_REPO_ISSUES=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_issues)
+      PUBLIC_REPO_ISSUES=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_issues)
      
       # Terraform doesn't like '.' in resource names, so if one exists then replace it with a dash
       TERRAFORM_PUBLIC_REPO_NAME=$(echo $i | tr  "."  "-")
@@ -58,7 +60,8 @@ EOF
 
 # Private Repos
 get_private_pagination () {
-  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=private&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1
+    priv_pages=$(curl -I "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=private&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
+    echo ${priv_pages:-1}
 }
 
 limit_private_pagination () {
@@ -68,15 +71,15 @@ limit_private_pagination () {
 import_private_repos () {
   for PAGE in $(limit_private_pagination); do
 
-    for i in $(curl -s "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=private&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
+    for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=private&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
   
-      PRIVATE_REPO_DESCRIPTION=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .description | sed "s/\"/'/g")
+      PRIVATE_REPO_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .description | sed "s/\"/'/g")
       
-      PRIVATE_REPO_DOWNLOADS=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_downloads)
+      PRIVATE_REPO_DOWNLOADS=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_downloads)
       
-      PRIVATE_REPO_WIKI=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_wiki)
+      PRIVATE_REPO_WIKI=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_wiki)
       
-      PRIVATE_REPO_ISSUES=$(curl -s "https://api.github.com/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_issues)
+      PRIVATE_REPO_ISSUES=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_issues)
      
       # Terraform doesn't like '.' in resource names, so if one exists then replace it with a dash
       TERRAFORM_PRIVATE_REPO_NAME=$(echo $i | tr  "."  "-")
@@ -100,7 +103,7 @@ EOF
 
 # Users
 import_users () {
-  for i in $(curl -s "https://api.github.com/orgs/$ORG/members?access_token=$GITHUB_TOKEN&per_page=100" | jq -r 'sort_by(.login) | .[] | .login'); do
+  for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/members?access_token=$GITHUB_TOKEN&per_page=100" | jq -r 'sort_by(.login) | .[] | .login'); do
 
   cat >> github-users.tf << EOF
 resource "github_membership" "$i" {
@@ -114,13 +117,13 @@ EOF
 
 # Teams
 import_teams () {
-  for i in $(curl -s "https://api.github.com/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
+  for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
   
-    TEAM_NAME=$(curl -s "https://api.github.com/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
+    TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
 
-    TEAM_PRIVACY=$(curl -s "https://api.github.com/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .privacy)
+    TEAM_PRIVACY=$(curl -s "${API_URL_PREFIX}/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .privacy)
   
-    TEAM_DESCRIPTION=$(curl -s "https://api.github.com/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .description)
+    TEAM_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .description)
   
     if [[ "$TEAM_PRIVACY" == "closed" ]]; then
       cat >> github-teams-$TEAM_NAME.tf << EOF
@@ -146,13 +149,13 @@ EOF
 
 # Team Memberships 
 import_team_memberships () {
-  for i in $(curl -s "https://api.github.com/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
+  for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
   
-  TEAM_NAME=$(curl -s "https://api.github.com/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
+  TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
   
-    for j in $(curl -s "https://api.github.com/teams/$i/members?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .[].login); do
+    for j in $(curl -s "${API_URL_PREFIX}/teams/$i/members?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .[].login); do
     
-      TEAM_ROLE=$(curl -s "https://api.github.com/teams/$i/memberships/$j?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .role)
+      TEAM_ROLE=$(curl -s "${API_URL_PREFIX}/teams/$i/memberships/$j?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .role)
 
       if [[ "$TEAM_ROLE" == "maintainer" ]]; then
         cat >> github-team-memberships-$TEAM_NAME.tf << EOF
@@ -177,7 +180,8 @@ EOF
 }
 
 get_team_pagination () {
-  curl -I "https://api.github.com/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1
+    team_pages=$(curl -I "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
+    echo ${team_pages:-1}
 }
   # This function uses the out from above and creates an array counting from 1->$ 
 limit_team_pagination () {
@@ -185,20 +189,20 @@ limit_team_pagination () {
 }
 
 get_team_ids () {
-  curl -s "https://api.github.com/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'
+  curl -s "${API_URL_PREFIX}/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'
 }
 
 get_team_repos () {
   for PAGE in $(limit_team_pagination); do
 
-    for i in $(curl -s "https://api.github.com/teams/$TEAM_ID/repos?access_token=$GITHUB_TOKEN&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
+    for i in $(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID/repos?access_token=$GITHUB_TOKEN&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
     
     TERRAFORM_TEAM_REPO_NAME=$(echo $i | tr  "."  "-")
-    TEAM_NAME=$(curl -s "https://api.github.com/teams/$TEAM_ID?access_token=$GITHUB_TOKEN" | jq -r .name)
+    TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID?access_token=$GITHUB_TOKEN" | jq -r .name)
 
-    ADMIN_PERMS=$(curl -s "https://api.github.com/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.admin )
-    PUSH_PERMS=$(curl -s "https://api.github.com/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.push )
-    PULL_PERMS=$(curl -s "https://api.github.com/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.pull )
+    ADMIN_PERMS=$(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.admin )
+    PUSH_PERMS=$(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.push )
+    PULL_PERMS=$(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.pull )
   
     if [[ "$ADMIN_PERMS" == "true" ]]; then
       cat >> github-teams-$TEAM_NAME.tf << EOF


### PR DESCRIPTION
- Support GitHub Enterprise by not hard coding the `API_URL_PREFIX`.
- Fix the `get_*_pagination` routines so that they do the right thing
  when there are fewer than 100 thingies.
- Enhance the documentation:
  - create a starter `main.tf` so that the `terraform import` commands
    to the right thing;
  - run `terraform init` to pull down the GitHub provider; and
  - set the URL prefix appropriately if using GitHub Enterprise.