### PR TITLE
Fix ShellCheck warnings (mostly quotation)

### DIFF
--- a/terraform-import-github-org.sh
+++ b/terraform-import-github-org.sh
@@ -16,223 +16,223 @@ API_URL_PREFIX=${API_URL_PREFIX:-'https://api.github.com'}
   # You can only list 100 items per page, so you can only clone 100 at a time.
   # This function uses the API to calculate how many pages of public repos you have.
 get_public_pagination () {
-    public_pages=$(curl -I "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
-    echo ${public_pages:-1}
+    public_pages=$(curl -I "${API_URL_PREFIX}/orgs/${ORG}/repos?access_token=${GITHUB_TOKEN}&type=public&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
+    echo "${public_pages:-1}"
 }
   # This function uses the output from above and creates an array counting from 1->$ 
 limit_public_pagination () {
-  seq $(get_public_pagination)
+  seq "$(get_public_pagination)"
 }
 
   # Now lets import the repos, starting with page 1 and iterating through the pages
 import_public_repos () {
   for PAGE in $(limit_public_pagination); do
   
-    for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=public&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
+    for i in $(curl -s "${API_URL_PREFIX}/orgs/${ORG}/repos?access_token=${GITHUB_TOKEN}&type=public&page=${PAGE}&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
   
   
-      PUBLIC_REPO_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .description | sed "s/\"/'/g")
-      PUBLIC_REPO_DOWNLOADS=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_downloads)
+      PUBLIC_REPO_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" | jq -r .description | sed "s/\"/'/g")
+      PUBLIC_REPO_DOWNLOADS=$(curl -s "${API_URL_PREFIX}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" | jq -r .has_downloads)
       
-      PUBLIC_REPO_WIKI=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_wiki)
+      PUBLIC_REPO_WIKI=$(curl -s "${API_URL_PREFIX}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" | jq -r .has_wiki)
       
-      PUBLIC_REPO_ISSUES=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_issues)
+      PUBLIC_REPO_ISSUES=$(curl -s "${API_URL_PREFIX}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" | jq -r .has_issues)
      
       # Terraform doesn't like '.' in resource names, so if one exists then replace it with a dash
-      TERRAFORM_PUBLIC_REPO_NAME=$(echo $i | tr  "."  "-")
+      TERRAFORM_PUBLIC_REPO_NAME=$(echo "${i}" | tr  "."  "-")
 
       cat >> github-public-repos.tf << EOF
-resource "github_repository" "$TERRAFORM_PUBLIC_REPO_NAME" {
-  name        = "$i"
+resource "github_repository" "${TERRAFORM_PUBLIC_REPO_NAME}" {
+  name        = "${i}"
   private     = false
-  description = "$PUBLIC_REPO_DESCRIPTION"
-  has_wiki    = "$PUBLIC_REPO_WIKI"
-  has_downloads = "$PUBLIC_REPO_DOWNLOADS"
-  has_issues  = "$PUBLIC_REPO_ISSUES"
+  description = "${PUBLIC_REPO_DESCRIPTION}"
+  has_wiki    = "${PUBLIC_REPO_WIKI}"
+  has_downloads = "${PUBLIC_REPO_DOWNLOADS}"
+  has_issues  = "${PUBLIC_REPO_ISSUES}"
 }
 EOF
 
       # Import the Repo
-      terraform import github_repository.$TERRAFORM_PUBLIC_REPO_NAME $i
+      terraform import "github_repository.${TERRAFORM_PUBLIC_REPO_NAME}" "${i}"
     done
   done
 }
 
 # Private Repos
 get_private_pagination () {
-    priv_pages=$(curl -I "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=private&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
-    echo ${priv_pages:-1}
+    priv_pages=$(curl -I "${API_URL_PREFIX}/orgs/${ORG}/repos?access_token=${GITHUB_TOKEN}&type=private&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
+    echo "${priv_pages:-1}"
 }
 
 limit_private_pagination () {
-  seq $(get_private_pagination)
+  seq "$(get_private_pagination)"
 }
 
 import_private_repos () {
   for PAGE in $(limit_private_pagination); do
 
-    for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&type=private&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
+    for i in $(curl -s "${API_URL_PREFIX}/orgs/${ORG}/repos?access_token=${GITHUB_TOKEN}&type=private&page=${PAGE}&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
   
-      PRIVATE_REPO_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .description | sed "s/\"/'/g")
+      PRIVATE_REPO_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" | jq -r .description | sed "s/\"/'/g")
       
-      PRIVATE_REPO_DOWNLOADS=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_downloads)
+      PRIVATE_REPO_DOWNLOADS=$(curl -s "${API_URL_PREFIX}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" | jq -r .has_downloads)
       
-      PRIVATE_REPO_WIKI=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_wiki)
+      PRIVATE_REPO_WIKI=$(curl -s "${API_URL_PREFIX}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" | jq -r .has_wiki)
       
-      PRIVATE_REPO_ISSUES=$(curl -s "${API_URL_PREFIX}/repos/$ORG/$i?access_token=$GITHUB_TOKEN" | jq -r .has_issues)
+      PRIVATE_REPO_ISSUES=$(curl -s "${API_URL_PREFIX}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" | jq -r .has_issues)
      
       # Terraform doesn't like '.' in resource names, so if one exists then replace it with a dash
-      TERRAFORM_PRIVATE_REPO_NAME=$(echo $i | tr  "."  "-")
+      TERRAFORM_PRIVATE_REPO_NAME=$(echo "${i}" | tr  "."  "-")
 
       cat >> github-private-repos.tf << EOF
-resource "github_repository" "$TERRAFORM_PRIVATE_REPO_NAME" {
-  name        = "$i"
+resource "github_repository" "${TERRAFORM_PRIVATE_REPO_NAME}" {
+  name        = "${i}"
   private     = true
-  description = "$PRIVATE_REPO_DESCRIPTION"
-  has_wiki    = "$PRIVATE_REPO_WIKI"
-  has_downloads = "$PRIVATE_REPO_DOWNLOADS"
-  has_issues  = "$PRIVATE_REPO_ISSUES"
+  description = "${PRIVATE_REPO_DESCRIPTION}"
+  has_wiki    = "${PRIVATE_REPO_WIKI}"
+  has_downloads = "${PRIVATE_REPO_DOWNLOADS}"
+  has_issues  = "${PRIVATE_REPO_ISSUES}"
 }
 
 EOF
       # Import the Repo
-      terraform import github_repository.$TERRAFORM_PRIVATE_REPO_NAME $i
+      terraform import "github_repository.${TERRAFORM_PRIVATE_REPO_NAME}" "${i}"
     done
   done
 }
 
 # Users
 import_users () {
-  for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/members?access_token=$GITHUB_TOKEN&per_page=100" | jq -r 'sort_by(.login) | .[] | .login'); do
+  for i in $(curl -s "${API_URL_PREFIX}/orgs/${ORG}/members?access_token=${GITHUB_TOKEN}&per_page=100" | jq -r 'sort_by(.login) | .[] | .login'); do
 
   cat >> github-users.tf << EOF
-resource "github_membership" "$i" {
-  username        = "$i"
+resource "github_membership" "${i}" {
+  username        = "${i}"
   role            = "member"
 }
 EOF
-    terraform import github_membership.$i $ORG:$i
+    terraform import "github_membership.${i}" "${ORG}:${i}"
   done
 }
 
 # Teams
 import_teams () {
-  for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
+  for i in $(curl -s "${API_URL_PREFIX}/orgs/${ORG}/teams?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
   
-    TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
+    TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/${i}?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
 
-    TEAM_PRIVACY=$(curl -s "${API_URL_PREFIX}/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .privacy)
+    TEAM_PRIVACY=$(curl -s "${API_URL_PREFIX}/teams/${i}?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .privacy)
   
-    TEAM_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .description)
+    TEAM_DESCRIPTION=$(curl -s "${API_URL_PREFIX}/teams/${i}?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .description)
   
-    if [[ "$TEAM_PRIVACY" == "closed" ]]; then
-      cat >> github-teams-$TEAM_NAME.tf << EOF
-resource "github_team" "$TEAM_NAME" {
-  name        = "$TEAM_NAME"
-  description = "$TEAM_DESCRIPTION"
+    if [[ "${TEAM_PRIVACY}" == "closed" ]]; then
+      cat >> "github-teams-${TEAM_NAME}.tf" << EOF
+resource "github_team" "${TEAM_NAME}" {
+  name        = "${TEAM_NAME}"
+  description = "${TEAM_DESCRIPTION}"
   privacy     = "closed"
 }
 EOF
-    elif [[ "$TEAM_PRIVACY" == "secret" ]]; then
-      cat >> github-teams-$TEAM_NAME.tf << EOF
-resource "github_team" "$TEAM_NAME" {
-  name        = "$TEAM_NAME"
-  description = "$TEAM_DESCRIPTION"
+    elif [[ "${TEAM_PRIVACY}" == "secret" ]]; then
+      cat >> "github-teams-${TEAM_NAME}.tf" << EOF
+resource "github_team" "${TEAM_NAME}" {
+  name        = "${TEAM_NAME}"
+  description = "${TEAM_DESCRIPTION}"
   privacy     = "secret"
 }
 EOF
     fi
 
-    terraform import github_team.$TEAM_NAME $i
+    terraform import "github_team.${TEAM_NAME}" "${i}"
   done
 }
 
 # Team Memberships 
 import_team_memberships () {
-  for i in $(curl -s "${API_URL_PREFIX}/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
+  for i in $(curl -s "${API_URL_PREFIX}/orgs/${ORG}/teams?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'); do
   
-  TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/$i?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
+  TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/${i}?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .name)
   
-    for j in $(curl -s "${API_URL_PREFIX}/teams/$i/members?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .[].login); do
+    for j in $(curl -s "${API_URL_PREFIX}/teams/${i}/members?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .[].login); do
     
-      TEAM_ROLE=$(curl -s "${API_URL_PREFIX}/teams/$i/memberships/$j?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .role)
+      TEAM_ROLE=$(curl -s "${API_URL_PREFIX}/teams/${i}/memberships/${j}?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r .role)
 
-      if [[ "$TEAM_ROLE" == "maintainer" ]]; then
-        cat >> github-team-memberships-$TEAM_NAME.tf << EOF
-resource "github_team_membership" "$TEAM_NAME-$j" {
-  username    = "$j"
-  team_id     = "\${github_team.$TEAM_NAME.id}"
+      if [[ "${TEAM_ROLE}" == "maintainer" ]]; then
+        cat >> "github-team-memberships-${TEAM_NAME}.tf" << EOF
+resource "github_team_membership" "${TEAM_NAME}-${j}" {
+  username    = "${j}"
+  team_id     = "\${github_team.${TEAM_NAME}.id}"
   role        = "maintainer"
 }
 EOF
-      elif [[ "$TEAM_ROLE" == "member" ]]; then
-        cat >> github-team-memberships-$TEAM_NAME.tf << EOF
-resource "github_team_membership" "$TEAM_NAME-$j" {
-  username    = "$j"
-  team_id     = "\${github_team.$TEAM_NAME.id}"
+      elif [[ "${TEAM_ROLE}" == "member" ]]; then
+        cat >> "github-team-memberships-${TEAM_NAME}.tf" << EOF
+resource "github_team_membership" "${TEAM_NAME}-${j}" {
+  username    = "${j}"
+  team_id     = "\${github_team.${TEAM_NAME}.id}"
   role        = "member"
 }
 EOF
       fi
-      terraform import github_team_membership.$TEAM_NAME-$j $i:$j
+      terraform import "github_team_membership.${TEAM_NAME}-${j}" "${i}:${j}"
     done
   done
 }
 
 get_team_pagination () {
-    team_pages=$(curl -I "${API_URL_PREFIX}/orgs/$ORG/repos?access_token=$GITHUB_TOKEN&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
-    echo ${team_pages:-1}
+    team_pages=$(curl -I "${API_URL_PREFIX}/orgs/${ORG}/repos?access_token=${GITHUB_TOKEN}&per_page=100" | grep -Eo '&page=\d+' | grep -Eo '[0-9]+' | tail -1;)
+    echo "${team_pages:-1}"
 }
   # This function uses the out from above and creates an array counting from 1->$ 
 limit_team_pagination () {
-  seq $(get_team_pagination)
+  seq "$(get_team_pagination)"
 }
 
 get_team_ids () {
-  curl -s "${API_URL_PREFIX}/orgs/$ORG/teams?access_token=$GITHUB_TOKEN&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'
+  curl -s "${API_URL_PREFIX}/orgs/${ORG}/teams?access_token=${GITHUB_TOKEN}&per_page=100" -H "Accept: application/vnd.github.hellcat-preview+json" | jq -r 'sort_by(.name) | .[] | .id'
 }
 
 get_team_repos () {
   for PAGE in $(limit_team_pagination); do
 
-    for i in $(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID/repos?access_token=$GITHUB_TOKEN&page=$PAGE&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
+    for i in $(curl -s "${API_URL_PREFIX}/teams/${TEAM_ID}/repos?access_token=${GITHUB_TOKEN}&page=${PAGE}&per_page=100" | jq -r 'sort_by(.name) | .[] | .name'); do
     
-    TERRAFORM_TEAM_REPO_NAME=$(echo $i | tr  "."  "-")
-    TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID?access_token=$GITHUB_TOKEN" | jq -r .name)
+    TERRAFORM_TEAM_REPO_NAME=$(echo "${i}" | tr  "."  "-")
+    TEAM_NAME=$(curl -s "${API_URL_PREFIX}/teams/${TEAM_ID}?access_token=${GITHUB_TOKEN}" | jq -r .name)
 
-    ADMIN_PERMS=$(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.admin )
-    PUSH_PERMS=$(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.push )
-    PULL_PERMS=$(curl -s "${API_URL_PREFIX}/teams/$TEAM_ID/repos/$ORG/$i?access_token=$GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.pull )
+    ADMIN_PERMS=$(curl -s "${API_URL_PREFIX}/teams/${TEAM_ID}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.admin )
+    PUSH_PERMS=$(curl -s "${API_URL_PREFIX}/teams/${TEAM_ID}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.push )
+    PULL_PERMS=$(curl -s "${API_URL_PREFIX}/teams/${TEAM_ID}/repos/${ORG}/${i}?access_token=${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.repository+json" | jq -r .permissions.pull )
   
-    if [[ "$ADMIN_PERMS" == "true" ]]; then
-      cat >> github-teams-$TEAM_NAME.tf << EOF
-resource "github_team_repository" "$TEAM_NAME-$TERRAFORM_TEAM_REPO_NAME" {
-  team_id    = "$TEAM_ID"
-  repository = "$i"
+    if [[ "${ADMIN_PERMS}" == "true" ]]; then
+      cat >> "github-teams-${TEAM_NAME}.tf" << EOF
+resource "github_team_repository" "${TEAM_NAME}-${TERRAFORM_TEAM_REPO_NAME}" {
+  team_id    = "${TEAM_ID}"
+  repository = "${i}"
   permission = "admin"
 }
 
 EOF
-    elif [[ "$PUSH_PERMS" == "true" ]]; then
-      cat >> github-teams-$TEAM_NAME.tf << EOF
-resource "github_team_repository" "$TEAM_NAME-$TERRAFORM_TEAM_REPO_NAME" {
-  team_id    = "$TEAM_ID"
-  repository = "$i"
+    elif [[ "${PUSH_PERMS}" == "true" ]]; then
+      cat >> "github-teams-${TEAM_NAME}.tf" << EOF
+resource "github_team_repository" "${TEAM_NAME}-${TERRAFORM_TEAM_REPO_NAME}" {
+  team_id    = "${TEAM_ID}"
+  repository = "${i}"
   permission = "push"
 }
 
 EOF
-    elif [[ "$PULL_PERMS" == "true" ]]; then
-      cat >> github-teams-$TEAM_NAME.tf << EOF
-resource "github_team_repository" "$TEAM_NAME-$TERRAFORM_TEAM_REPO_NAME" {
-  team_id    = "$TEAM_ID"
-  repository = "$i"
+    elif [[ "${PULL_PERMS}" == "true" ]]; then
+      cat >> "github-teams-${TEAM_NAME}.tf" << EOF
+resource "github_team_repository" "${TEAM_NAME}-${TERRAFORM_TEAM_REPO_NAME}" {
+  team_id    = "${TEAM_ID}"
+  repository = "${i}"
   permission = "pull"
 }
 
 EOF
     fi
-    terraform import github_team_repository.$TEAM_NAME-$TERRAFORM_TEAM_REPO_NAME $TEAM_ID:$i
+    terraform import "github_team_repository.${TEAM_NAME}-${TERRAFORM_TEAM_REPO_NAME}" "${TEAM_ID}:${i}"
     done
   done
 }


### PR DESCRIPTION
Output of ShellCheck before changes:
```
In terraform-import-github-org.sh line 20:
    echo ${public_pages:-1}
         ^----------------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 24:
  seq $(get_public_pagination)
      ^----------------------^ SC2046: Quote this to prevent word splitting.

In terraform-import-github-org.sh line 42:
      TERRAFORM_PUBLIC_REPO_NAME=$(echo $i | tr  "."  "-")
                                        ^-- SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 56:
      terraform import github_repository.$TERRAFORM_PUBLIC_REPO_NAME $i
                                         ^-------------------------^ SC2086: Double quote to prevent globbing and word splitting.
                                                                     ^-- SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 64:
    echo ${priv_pages:-1}
         ^--------------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 68:
  seq $(get_private_pagination)
      ^-----------------------^ SC2046: Quote this to prevent word splitting.

In terraform-import-github-org.sh line 85:
      TERRAFORM_PRIVATE_REPO_NAME=$(echo $i | tr  "."  "-")
                                         ^-- SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 99:
      terraform import github_repository.$TERRAFORM_PRIVATE_REPO_NAME $i
                                         ^--------------------------^ SC2086: Double quote to prevent globbing and word splitting.
                                                                      ^-- SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 114:
    terraform import github_membership.$i $ORG:$i
                                       ^-- SC2086: Double quote to prevent globbing and word splitting.
                                          ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                               ^-- SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 129:
      cat >> github-teams-$TEAM_NAME.tf << EOF
                          ^--------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 137:
      cat >> github-teams-$TEAM_NAME.tf << EOF
                          ^--------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 146:
    terraform import github_team.$TEAM_NAME $i
                                 ^--------^ SC2086: Double quote to prevent globbing and word splitting.
                                            ^-- SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 161:
        cat >> github-team-memberships-$TEAM_NAME.tf << EOF
                                       ^--------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 169:
        cat >> github-team-memberships-$TEAM_NAME.tf << EOF
                                       ^--------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 177:
      terraform import github_team_membership.$TEAM_NAME-$j $i:$j
                                              ^--------^ SC2086: Double quote to prevent globbing and word splitting.
                                                         ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                            ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                               ^-- SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 184:
    echo ${team_pages:-1}
         ^--------------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 188:
  seq $(get_team_pagination)
      ^--------------------^ SC2046: Quote this to prevent word splitting.

In terraform-import-github-org.sh line 200:
    TERRAFORM_TEAM_REPO_NAME=$(echo $i | tr  "."  "-")
                                    ^-- SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 208:
      cat >> github-teams-$TEAM_NAME.tf << EOF
                          ^--------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 217:
      cat >> github-teams-$TEAM_NAME.tf << EOF
                          ^--------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 226:
      cat >> github-teams-$TEAM_NAME.tf << EOF
                          ^--------^ SC2086: Double quote to prevent globbing and word splitting.

In terraform-import-github-org.sh line 235:
    terraform import github_team_repository.$TEAM_NAME-$TERRAFORM_TEAM_REPO_NAME $TEAM_ID:$i
                                            ^--------^ SC2086: Double quote to prevent globbing and word splitting.
                                                       ^-----------------------^ SC2086: Double quote to prevent globbing and word splitting.
                                                                                 ^------^ SC2086: Double quote to prevent globbing and word splitting.
                                                                                          ^-- SC2086: Double quote to prevent globbing and word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

Output of ShellCheck after changes is empty.